### PR TITLE
Added new settings option: JWT_AUTHORIZATION_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ components = [
 ]
 ```
 
+`JWT_AUTHORIZATION_PREFIX` is the string that comes before the token in the Authorization header. Defaults to 'bearer' (Does not case sensitive)
+
+```python
+from apistar_jwt.token import JWT
+
+components = [
+  JWT({
+    'JWT_AUTHORIZATION_PREFIX': 'jwt'
+  })
+]
+```
+
 `JWT_SECRET` is a long, randomized, secret key that should never be checked into version control.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ components = [
 ]
 ```
 
-`JWT_AUTHORIZATION_PREFIX` is the string that comes before the token in the Authorization header. Defaults to 'bearer' (Does not case sensitive)
+`JWT_AUTHORIZATION_PREFIX` is the string that comes before the token in the Authorization header. Defaults to 'bearer' (the header is not case sensitive)
 
 ```python
 from apistar_jwt.token import JWT

--- a/apistar_jwt/token.py
+++ b/apistar_jwt/token.py
@@ -77,6 +77,7 @@ class JWT(Component):
             'options': get('JWT_OPTIONS', {}),
             'secret': get('JWT_SECRET'),
             "white_list": get("JWT_WHITE_LIST", []),
+            'authorization_prefix': get('JWT_AUTHORIZATION_PREFIX', 'bearer'),
         }
         if self.settings['secret'] is None:
             self._raise_setup_error()
@@ -97,7 +98,7 @@ class JWT(Component):
             return None
         if authorization is None and not authentication_required:
             return None
-        token = get_token_from_header(authorization)
+        token = get_token_from_header(authorization, self.settings['authorization_prefix'])
         jwt_user = jwt.decode(token)
         if jwt_user is None:
             raise AuthenticationFailed()

--- a/apistar_jwt/token.py
+++ b/apistar_jwt/token.py
@@ -76,7 +76,7 @@ class JWT(Component):
             'algorithms': get('JWT_ALGORITHMS', ['HS256']),
             'options': get('JWT_OPTIONS', {}),
             'secret': get('JWT_SECRET'),
-            "white_list": get("JWT_WHITE_LIST", []),
+            'white_list': get('JWT_WHITE_LIST', []),
             'authorization_prefix': get('JWT_AUTHORIZATION_PREFIX', 'bearer'),
         }
         if self.settings['secret'] is None:

--- a/apistar_jwt/utils.py
+++ b/apistar_jwt/utils.py
@@ -3,13 +3,13 @@ from apistar import http
 from .exceptions import AuthenticationFailed
 
 
-def get_token_from_header(authorization: http.Header):
+def get_token_from_header(authorization: http.Header, authorization_prefix: str):
     if authorization is None:
         raise AuthenticationFailed('Authorization header is missing.')
     try:
         scheme, token = authorization.split()
     except ValueError:
         raise AuthenticationFailed('Could not seperate Authorization scheme and token.')
-    if scheme.lower() != 'bearer':
+    if scheme.lower() != authorization_prefix:
         raise AuthenticationFailed('Authorization scheme not supported, try Bearer')
     return token


### PR DESCRIPTION
to support other strings in the Authorization header instead bearer.